### PR TITLE
doc(xero): source package hyperlink update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The package’s primary focus is to transform the core tables into analytics-rea
 
 ## Models
 
-This package contains transformation models, designed to work simultaneously with our [Xero source package](https://github.com/fivetran/xero_source). A dependency on the source package is declared in this package's `packages.yml` file, so it will automatically download when you run `dbt deps`. The primary outputs of this package are described below.
+This package contains transformation models, designed to work simultaneously with our [Xero source package](https://github.com/fivetran/dbt_xero_source/tree/v0.1.0/). A dependency on the source package is declared in this package's `packages.yml` file, so it will automatically download when you run `dbt deps`. The primary outputs of this package are described below.
 
 | **model**                     | **description**                                                                                                        |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The package’s primary focus is to transform the core tables into analytics-rea
 
 ## Models
 
-This package contains transformation models, designed to work simultaneously with our [Xero source package](https://github.com/fivetran/dbt_xero_source/tree/v0.1.0/). A dependency on the source package is declared in this package's `packages.yml` file, so it will automatically download when you run `dbt deps`. The primary outputs of this package are described below.
+This package contains transformation models, designed to work simultaneously with our [Xero source package](https://github.com/fivetran/dbt_xero_source/). A dependency on the source package is declared in this package's `packages.yml` file, so it will automatically download when you run `dbt deps`. The primary outputs of this package are described below.
 
 | **model**                     | **description**                                                                                                        |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The source package link on the transform package readme is broken. 

![image](https://user-images.githubusercontent.com/60129976/115339989-82cb7a80-a1c3-11eb-970e-c72592853657.png)
